### PR TITLE
Add support for VSCode integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 .DS_Store
 [Dd]ebug/
 [Rr]elease/
-.vs
+.vs*

--- a/cores/blinkcore/sp.cpp
+++ b/cores/blinkcore/sp.cpp
@@ -45,6 +45,10 @@ uint8_t sp_aux_analogRead(void) {
 // Overrides digital mode for service port pins T and R respectively. 
 
 void sp_serial_init(void) {
+	sp_serial_init(500000);
+}
+
+void sp_serial_init(unsigned long _baudrate=500000) {
     
     //Initialize the AUX pin as digitalOut
     //SBI( SP_AUX_DDR , SP_AUX_PIN );
@@ -63,9 +67,23 @@ void sp_serial_init(void) {
         #error Serial port calculation in debug.cpp must be updated if not 4Mhz CPU clock.
     #endif
     
-    UBRR0 = 0;                  // 500Kbd. This is as fast as we can go at 4Mhz, and happens to be 0% error and supported by the Arduino serial monitor. 
-                                // See datasheet table 25-7. 
-        
+    /*
+     * kenj:
+     * UBRR calculation for async double speed is:
+     * (from http://masteringarduino.blogspot.com/2013/11/USART.html)
+     *    UBRR=(F_CPU/(8 * baudrate)-1)
+     */
+  switch(_baudrate) {
+    case 250000:
+		UBRR0=1;
+		break;
+    case 500000:
+    default:
+		UBRR0 = 0;                  // 500Kbd. This is as fast as we can go at 4Mhz, and happens to be 0% error and supported by the Arduino serial monitor. 
+                                    // See datasheet table 25-7. 
+		break;
+    break;
+  }
 }   
 
 // Free up service port pin R for digital IO again

--- a/cores/blinkcore/sp.h
+++ b/cores/blinkcore/sp.h
@@ -47,6 +47,7 @@
     // Also enables the pull-up on the RX pin so it can be connected to an open-collector output
     
     void sp_serial_init(void);
+    void sp_serial_init(unsigned long _baudrate);
         
     // Send a byte out the serial port. Blocks if a transmit already in progress. 
     // Must call sp_serial_init() first

--- a/cores/blinkcore/sp.h
+++ b/cores/blinkcore/sp.h
@@ -47,7 +47,7 @@
     // Also enables the pull-up on the RX pin so it can be connected to an open-collector output
     
     void sp_serial_init(void);
-    void sp_serial_init(unsigned long _baudrate);
+    void sp_serial_init(unsigned long);
         
     // Send a byte out the serial port. Blocks if a transmit already in progress. 
     // Must call sp_serial_init() first

--- a/libraries/blinklib/src/Serial.cpp
+++ b/libraries/blinklib/src/Serial.cpp
@@ -29,6 +29,18 @@ void ServicePortSerial::begin(void)
   
 }
 
+void ServicePortSerial::begin(unsigned long _baudrate=500000) {
+  switch(_baudrate) {
+    case 250000:
+		sp_serial_init(250000);
+		break;
+    case 500000:
+    default:
+		sp_serial_init(500000);
+		break;
+  }
+}
+
 void ServicePortSerial::end()
 {    
     // TODO: Is there any reason to turn off the serial port? Power?

--- a/libraries/blinklib/src/Serial.cpp
+++ b/libraries/blinklib/src/Serial.cpp
@@ -25,19 +25,19 @@
 void ServicePortSerial::begin(void)
 {
     
-  sp_serial_init();
-  
+  sp_serial_init(DEF_SERVICE_PORT_BAUDRATE);
+
 }
 
-void ServicePortSerial::begin(unsigned long _baudrate=500000) {
+void ServicePortSerial::begin(unsigned long _baudrate=DEF_SERVICE_PORT_BAUDRATE) {
   switch(_baudrate) {
     case 250000:
-		sp_serial_init(250000);
-		break;
+      sp_serial_init(250000);
+      break;
     case 500000:
     default:
-		sp_serial_init(500000);
-		break;
+      sp_serial_init(500000);
+      break;
   }
 }
 

--- a/libraries/blinklib/src/Serial.h
+++ b/libraries/blinklib/src/Serial.h
@@ -16,6 +16,8 @@
 
     #include "Print.h"
 
+    #define DEF_SERVICE_PORT_BAUDRATE 500000
+
     class ServicePortSerial : public Print
     {
 
@@ -24,7 +26,7 @@
         //inline ServicePortSerialSerial(void);
     
         void begin(void); 
-        void begin(unsigned long _baudrate); 
+        void begin(unsigned long); 
         void end();
     
         virtual int available(void);

--- a/libraries/blinklib/src/Serial.h
+++ b/libraries/blinklib/src/Serial.h
@@ -24,6 +24,7 @@
         //inline ServicePortSerialSerial(void);
     
         void begin(void); 
+        void begin(unsigned long _baudrate); 
         void end();
     
         virtual int available(void);

--- a/programmers.txt
+++ b/programmers.txt
@@ -1,0 +1,8 @@
+# Added a faster upload speed for the USB Tiny ISP
+# this matches the speed of the AVRISP MKii
+# cuts programming time for Blinks to 25%
+blinksprogrammer.name=Blinks Programmer
+blinksprogrammer.communication=usb
+blinksprogrammer.protocol=usbtiny
+blinksprogrammer.program.tool=avrdude
+blinksprogrammer.program.extra_params=-B3

--- a/programmers.txt
+++ b/programmers.txt
@@ -1,8 +1,0 @@
-# Added a faster upload speed for the USB Tiny ISP
-# this matches the speed of the AVRISP MKii
-# cuts programming time for Blinks to 25%
-blinksprogrammer.name=Blinks Programmer
-blinksprogrammer.communication=usb
-blinksprogrammer.protocol=usbtiny
-blinksprogrammer.program.tool=avrdude
-blinksprogrammer.program.extra_params=-B3


### PR DESCRIPTION
The highest baud rate supported in the VSCode Serial Monitor is 250k. The default baud rate in Blinks is 500k.  With these changes, the user can specify either the 250k or 500k baud rate in the init method call, or use the default empty init method (as is) to stay with 500k (i.e. no changes should be required for users not using VSCode).  
