### PR TITLE
Updated per discussion: simpler, shields impl, pushes macros

### DIFF
--- a/libraries/blinklib/src/LogSerial.cpp
+++ b/libraries/blinklib/src/LogSerial.cpp
@@ -1,0 +1,76 @@
+/*
+ * This LogSerial class adds log level capability to the base ServicePortSerial class.  You should be
+ * able to replace your existing Serial.h with LogSerial.h and not require any other
+ * changes. All base print methods in ServicePortSerial are accessible.
+ * The LogSerial class adds 2 new print methods which support a "printf" style format string 
+ * and variable arguments.  
+ */
+
+#include <stdio.h>
+#include "LogSerial.h"
+
+static FILE _logOutput = {0};
+static LogSerial *_logSerial;
+
+static int logSerial_Putc(char c, FILE *file) {
+    _logSerial->write(c);
+}
+
+void LogSerial::begin() {
+    begin(500000);
+}
+
+void LogSerial::begin(unsigned long _baudrate) {
+
+    _logSerial=this;
+    ServicePortSerial::begin(_baudrate);
+    fdev_setup_stream(&_logOutput, logSerial_Putc, NULL, _FDEV_SETUP_WRITE);
+    stdout = stderr = &_logOutput;
+}
+
+void LogSerial::setLogLevel(LogLevel level) {
+    logLevel = level;
+}
+
+void LogSerial::enable() { enabled = true; }
+
+void LogSerial::disable() { enabled = false; }
+
+LogLevel LogSerial::getLogLevel() { 
+    return logLevel; 
+}
+
+bool LogSerial::shouldLog(LogLevel level) {
+    if(enabled && (logLevel >= level || level == LOG_ALL))
+        return true;
+
+    return false;
+}
+
+size_t LogSerial::print (LogLevel level, const char *fmt, ...) {
+    va_list vp;
+    int i;
+
+    if(!shouldLog(level))
+        return 0;
+    va_start(vp, fmt);
+	i = vfprintf(stdout, fmt, vp);
+	va_end(vp);
+
+	return i;
+}
+
+size_t LogSerial::print (LogLevel level, const __FlashStringHelper *fmt, ...) {
+    va_list vp;
+    int i;
+
+    if(!shouldLog(level))
+        return 0;
+    va_start(vp, fmt);
+ 	stdout->flags |= __SPGM;// using prog_mem
+	i = vfprintf_P(stdout, reinterpret_cast<const char *>(fmt), vp);
+	stdout->flags &= ~__SPGM;
+	va_end(vp);
+
+	return i;
+}

--- a/libraries/blinklib/src/LogSerial.cpp
+++ b/libraries/blinklib/src/LogSerial.cpp
@@ -1,58 +1,37 @@
+
 /*
- * This LogSerial class adds log level capability to the base ServicePortSerial class.  You should be
- * able to replace your existing Serial.h with LogSerial.h and not require any other
- * changes. All base print methods in ServicePortSerial are accessible.
- * The LogSerial class adds 2 new print methods which support a "printf" style format string 
- * and variable arguments.  
+ * LogSerial.cpp
  */
+
+// Just has to be non-zero to pull in the class
+#define USE_LOG_LEVEL LOG_ERROR
 
 #include <stdio.h>
 #include "LogSerial.h"
 
-static FILE _logOutput = {0};
-static LogSerial *_logSerial;
+static LogSerial *_logSerial = NULL;
 
 static int logSerial_Putc(char c, FILE *file) {
     _logSerial->write(c);
 }
 
-void LogSerial::begin() {
-    begin(500000);
+void LogSerial::init() {
+    init(500000);
 }
 
-void LogSerial::begin(unsigned long _baudrate) {
-
-    _logSerial=this;
-    ServicePortSerial::begin(_baudrate);
+void LogSerial::init(unsigned long _baudrate=500000) {
+    static FILE _logOutput = {0};
+ 
+    _logSerial=getInstance();
+    _logSerial->begin(_baudrate);
     fdev_setup_stream(&_logOutput, logSerial_Putc, NULL, _FDEV_SETUP_WRITE);
     stdout = stderr = &_logOutput;
 }
 
-void LogSerial::setLogLevel(LogLevel level) {
-    logLevel = level;
-}
-
-void LogSerial::enable() { enabled = true; }
-
-void LogSerial::disable() { enabled = false; }
-
-LogLevel LogSerial::getLogLevel() { 
-    return logLevel; 
-}
-
-bool LogSerial::shouldLog(LogLevel level) {
-    if(enabled && (logLevel >= level || level == LOG_ALL))
-        return true;
-
-    return false;
-}
-
-size_t LogSerial::print (LogLevel level, const char *fmt, ...) {
+size_t LogSerial::LOG_SERIAL_PRINT_METHOD_NAME (const char *fmt, ...) {
     va_list vp;
     int i;
 
-    if(!shouldLog(level))
-        return 0;
     va_start(vp, fmt);
 	i = vfprintf(stdout, fmt, vp);
 	va_end(vp);
@@ -60,12 +39,10 @@ size_t LogSerial::print (LogLevel level, const char *fmt, ...) {
 	return i;
 }
 
-size_t LogSerial::print (LogLevel level, const __FlashStringHelper *fmt, ...) {
+size_t LogSerial::LOG_SERIAL_PRINT_METHOD_NAME (const __FlashStringHelper *fmt, ...) {
     va_list vp;
     int i;
 
-    if(!shouldLog(level))
-        return 0;
     va_start(vp, fmt);
  	stdout->flags |= __SPGM;// using prog_mem
 	i = vfprintf_P(stdout, reinterpret_cast<const char *>(fmt), vp);

--- a/libraries/blinklib/src/LogSerial.cpp
+++ b/libraries/blinklib/src/LogSerial.cpp
@@ -3,9 +3,6 @@
  * LogSerial.cpp
  */
 
-// Just has to be non-zero to pull in the class
-#define USE_LOG_LEVEL LOG_ERROR
-
 #include <stdio.h>
 #include "LogSerial.h"
 
@@ -15,20 +12,16 @@ static int logSerial_Putc(char c, FILE *file) {
     _logSerial->write(c);
 }
 
-void LogSerial::init() {
-    init(500000);
-}
-
-void LogSerial::init(unsigned long _baudrate=500000) {
+void LogSerial::init(SerialMonitorBaudRate enumBaud=SM_BAUD_RATE_500K) {
     static FILE _logOutput = {0};
- 
+
     _logSerial=getInstance();
-    _logSerial->begin(_baudrate);
+    _logSerial->begin(enumBaud);
     fdev_setup_stream(&_logOutput, logSerial_Putc, NULL, _FDEV_SETUP_WRITE);
     stdout = stderr = &_logOutput;
 }
 
-size_t LogSerial::LOG_SERIAL_PRINT_METHOD_NAME (const char *fmt, ...) {
+size_t LogSerial::LogSerialPrint (const char *fmt, ...) {
     va_list vp;
     int i;
 
@@ -39,7 +32,7 @@ size_t LogSerial::LOG_SERIAL_PRINT_METHOD_NAME (const char *fmt, ...) {
 	return i;
 }
 
-size_t LogSerial::LOG_SERIAL_PRINT_METHOD_NAME (const __FlashStringHelper *fmt, ...) {
+size_t LogSerial::LogSerialPrint (const __FlashStringHelper *fmt, ...) {
     va_list vp;
     int i;
 

--- a/libraries/blinklib/src/LogSerial.h
+++ b/libraries/blinklib/src/LogSerial.h
@@ -144,7 +144,7 @@ class LogSerial : public ServicePortSerial {
 #define LOG(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ALL, fmt, ##__VA_ARGS__))
 #define LOGE(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ERROR, (LOG_ERROR_HEAD fmt), ##__VA_ARGS__))
 #define LOGW(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_WARN, (LOG_WARN_HEAD fmt), ##__VA_ARGS__))
-#define LOGI(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_INFO, (LOG_INFO_HEAD Format, ##__VA_ARGS__))
+#define LOGI(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_INFO, (LOG_INFO_HEAD fmt), ##__VA_ARGS__))
 #define LOGD(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_DEBUG, (LOG_DEBUG_HEAD fmt), ##__VA_ARGS__))
 
 // Wrap the format string in F() macro

--- a/libraries/blinklib/src/LogSerial.h
+++ b/libraries/blinklib/src/LogSerial.h
@@ -1,0 +1,173 @@
+/*
+ * This LogSerial class adds log level capability to the base ServicePortSerial class.  You should be
+ * able to replace your existing Serial.h with LogSerial.h and not require any other
+ * changes. All base print methods in ServicePortSerial are accessible.
+ * The LogSerial class adds 2 new print methods which support a "printf" style format string 
+ * and variable arguments.  
+ * 
+ * There are 5 Log levels (LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DEBUG, LOG_ALL).
+ 
+ * E.g.
+ * #include "LogSerial.h"
+ *  
+ * LogSerial lsp;
+ * 
+ * lsp.print(LOG_ERROR, "Yikes, error on line %d in %s\n", __LINE__, __FILE__);
+ * 
+ * The first parameter is the LOG_LEVEL, followed by the format string, and a variable number of arguments.
+ * The format string may be a const char * (stored in RAM) or a Flash string (PROG_MEM; recommended).
+ * The variable arguments can be any argument acceptable to the fprintf method.
+ * 
+ * Use the setLogLevel method to set the current log level (default Error).  E.g. setLogLevel(LOG_INFO);
+ * 
+ * Use the enable/disable methods to enable or disable (default) the display of Log message in the Serial Monitor.
+ * 
+ * To use the LogSerial class:
+ * 1) Include "LogSerial.h" (replaces your Serial.h, if needed)
+ * 2) Create a LogSerial instance
+ * 3) Call the begin method (with baudrate, or empty (default to 500k))
+ * 4) Set your log level using setLogLevel method
+ * 5) Call enable method to turn on log messaging
+ * 6) Use the appropriate print method (either in LogSerial, or the ServicePortSerial class)
+ * 
+ * CONVENIENCE MACROS:
+ * Convenience macros which mirror the Log levels are optionally defined (and customizable).
+ * The macros allow you to compile your sketch with or without Log messages (saving program and memory space). 
+ * There are 2 sets of macros; (1) uses the format string as-is, (2) wraps the format string
+ * in the F() macro so it's stored in Flash memory.
+ * 
+ * The macros are (first set, use format string as-is):
+ * LOG - Always log
+ * LOGE - Log an error message
+ * LOGW - Log a warning message
+ * LOGI - Log an informational message
+ * LOGD - Log a debug message
+ * 
+ * This 2nd set of macros will put the format string in Flash memory:
+ * LOGF - Always log
+ * LOGFE - Log an error message
+ * LOGFW - Log a warning message
+ * LOGFI - Log an informational message
+ * LOGFD - Log a debug message
+ * 
+ * The header string (e.g. "Error: ") for the LOGX macros are customizable.  To specify
+ * your own header string, override the equivalent #define (below) BEFORE including LogSerial.h. 
+ * The default header strings are:
+ * 
+ * #define LOG_ERROR_HEAD "ERROR: "
+ * #define LOG_WARN_HEAD "WARNING: "
+ * #define LOG_INFO_HEAD "INFO: "
+ * #define LOG_DEBUG_HEAD "DEBUG: "
+ *
+ * To use the macros, you must tell the pre-processor about your LogSerial instance.  To do this,
+ * specify a #define for LOG_SERIAL_INST *before* including the LogSerial.h include file.
+ * If LOG_SERIAL_INST is not defined, than these macros become empty statements in your sketch.
+ * 
+ * To use the LogSerial class and convenience macros (by default, the macros are empty):
+ * 
+ * 1) #define a LOG_SERIAL_INST *before* the Include.  It should point to your LogSerial instance.
+ * 2) Define any "Log header string" overrides
+ * 3) Include the LogSerial header file
+ * 4) Create a LogSerial instance
+ * 5) Call the begin method (with baudrate, or empty (default to 500k))
+ * 6) Set your log level using setLogLevel method
+ * 7) Call enable method to turn on log messaging
+ * 8) Use the appropriate macros or print methods (either in LogSerial, or the ServicePortSerial class)
+ * 
+ * E.g. Using macros...
+ * #define LOG_SERIAL_INST lsp
+ * // Specify my own LOG_INFO header string
+ * #define LOG_INFO_HEAD "[I]: "
+ * 
+ * #include "LogSerial.h"
+ * 
+ * LogSerial lsp;
+ * 
+ * LOGI("A somewhat informational format string: %s", F("Move along, nothing here"));
+ */
+#ifndef LogSerial_h
+
+#define LogSerial_h
+
+
+#include "Serial.h"
+
+enum LogLevel { LOG_ERROR=0, LOG_WARN=1, LOG_INFO=2, LOG_DEBUG=3, LOG_ALL=4 };
+
+/*
+ * If you want Log capability, instantiate this class instead of ServicePortSerial.
+ */
+class LogSerial : public ServicePortSerial {
+
+    public:
+
+    void begin();// defaults to 500k baud rate
+    void begin(unsigned long);// specify baud rate (250000 or 500000)
+
+    void setLogLevel(LogLevel);
+    LogLevel getLogLevel();
+ 
+    void enable();// enable logging
+    void disable();// disable logging
+
+    size_t print(LogLevel, const char *, ...);
+    size_t print(LogLevel, const __FlashStringHelper *, ...);
+
+    using Print::print;                     // pull in base print methods
+
+    private:
+
+    bool shouldLog(LogLevel);
+
+    LogLevel logLevel = LogLevel::LOG_ERROR;
+    bool enabled = false;
+};
+
+
+#ifdef LOG_SERIAL_INST
+
+// Users can override these header strings
+#ifndef LOG_ERROR_HEAD
+#define LOG_ERROR_HEAD "ERROR:  "
+#endif
+#ifndef LOG_WARN_HEAD
+#define LOG_WARN_HEAD "WARNING: "
+#endif
+#ifndef LOG_INFO_HEAD
+#define LOG_INFO_HEAD "INFO: "
+#endif
+#ifndef LOG_DEBUG_HEAD
+#define LOG_DEBUG_HEAD "DEBUG: "
+#endif
+
+// Use format string as-is
+#define LOG(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ALL, fmt, ##__VA_ARGS__))
+#define LOGE(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ERROR, (LOG_ERROR_HEAD fmt), ##__VA_ARGS__))
+#define LOGW(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_WARN, (LOG_WARN_HEAD fmt), ##__VA_ARGS__))
+#define LOGI(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_INFO, (LOG_INFO_HEAD Format, ##__VA_ARGS__))
+#define LOGD(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_DEBUG, (LOG_DEBUG_HEAD fmt), ##__VA_ARGS__))
+
+// Wrap the format string in F() macro
+#define LOGF(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ALL, F(fmt), ##__VA_ARGS__))
+#define LOGFE(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ERROR, F(LOG_ERROR_HEAD fmt), ##__VA_ARGS__))
+#define LOGFW(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_WARN, F(LOG_WARN_HEAD fmt), ##__VA_ARGS__))
+#define LOGFI(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_INFO, F(LOG_INFO_HEAD fmt), ##__VA_ARGS__))
+#define LOGFD(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_DEBUG, F(LOG_DEBUG_HEAD fmt), ##__VA_ARGS__))
+
+#else // LOG_SERIAL_INST not defined
+
+#define LOGA(fmt, ...) (void(0))
+#define LOGE(fmt, ...) (void(0))
+#define LOGW(fmt, ...) (void(0))
+#define LOGI(fmt, ...) (void(0))
+#define LOGD(fmt, ...) (void(0))
+
+#define LOGFA(fmt, ...) (void(0))
+#define LOGFE(fmt, ...) (void(0))
+#define LOGFW(fmt, ...) (void(0))
+#define LOGFI(fmt, ...) (void(0))
+#define LOGFD(fmt, ...) (void(0))
+
+#endif // LOG_SERIAL_INST
+
+#endif

--- a/libraries/blinklib/src/LogSerial.h
+++ b/libraries/blinklib/src/LogSerial.h
@@ -1,173 +1,198 @@
 /*
- * This LogSerial class adds log level capability to the base ServicePortSerial class.  You should be
- * able to replace your existing Serial.h with LogSerial.h and not require any other
- * changes. All base print methods in ServicePortSerial are accessible.
- * The LogSerial class adds 2 new print methods which support a "printf" style format string 
- * and variable arguments.  
- * 
- * There are 5 Log levels (LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DEBUG, LOG_ALL).
+Supports either 250k or 500k (default) baud rate for the Serial Monitor port. (VSCode max is 250k)
+
+Note: LogSerial does not preclude the use of the ServicePortSerial class or methods.  
+However, to realize the above benefits, users may want to transition to LogSerial. 
+
+To use LogSerial functionality:
+ 1) Define a USE_LOG_LEVEL at the beginning of your sketch.
+ 2) Include "LogSerial.h"
+ 3) Call the LOG_SERIAL_BEGIN macro in your setup method (with baudrate, or empty (default to 500k))
+ 4) Use the appropriate LogSerial macro's
+
+Defining USE_LOG_LEVEL:
+To compile away all LogSerial macros, either do not define USE_LOG_LEVEL or set its value to LOG_NONE.
+To include all log levels, set USE_LOG_LEVEL to LOG_DEBUG (or LOG_ALL).
+To only include errors, set USE_LOG_LEVEL to LOG_ERROR.  (All other log messages are compiled away.)
+To only include errors and warnings, set USE_LOG_LEVEL to LOG_WARN. (Info and Debug log messages are compiled away.)
+Etc.
+
+LogSerial Macros:
+The LogSerial macro composition: 
+  // macroName( formatString, variableArgs)
+  LOGx ( formatString, ...)
+
+There are 2 sets of macros;
  
- * E.g.
- * #include "LogSerial.h"
- *  
- * LogSerial lsp;
- * 
- * lsp.print(LOG_ERROR, "Yikes, error on line %d in %s\n", __LINE__, __FILE__);
- * 
- * The first parameter is the LOG_LEVEL, followed by the format string, and a variable number of arguments.
- * The format string may be a const char * (stored in RAM) or a Flash string (PROG_MEM; recommended).
- * The variable arguments can be any argument acceptable to the fprintf method.
- * 
- * Use the setLogLevel method to set the current log level (default Error).  E.g. setLogLevel(LOG_INFO);
- * 
- * Use the enable/disable methods to enable or disable (default) the display of Log message in the Serial Monitor.
- * 
- * To use the LogSerial class:
- * 1) Include "LogSerial.h" (replaces your Serial.h, if needed)
- * 2) Create a LogSerial instance
- * 3) Call the begin method (with baudrate, or empty (default to 500k))
- * 4) Set your log level using setLogLevel method
- * 5) Call enable method to turn on log messaging
- * 6) Use the appropriate print method (either in LogSerial, or the ServicePortSerial class)
- * 
- * CONVENIENCE MACROS:
- * Convenience macros which mirror the Log levels are optionally defined (and customizable).
- * The macros allow you to compile your sketch with or without Log messages (saving program and memory space). 
- * There are 2 sets of macros; (1) uses the format string as-is, (2) wraps the format string
- * in the F() macro so it's stored in Flash memory.
- * 
- * The macros are (first set, use format string as-is):
- * LOG - Always log
- * LOGE - Log an error message
- * LOGW - Log a warning message
- * LOGI - Log an informational message
- * LOGD - Log a debug message
- * 
- * This 2nd set of macros will put the format string in Flash memory:
- * LOGF - Always log
- * LOGFE - Log an error message
- * LOGFW - Log a warning message
- * LOGFI - Log an informational message
- * LOGFD - Log a debug message
- * 
- * The header string (e.g. "Error: ") for the LOGX macros are customizable.  To specify
- * your own header string, override the equivalent #define (below) BEFORE including LogSerial.h. 
- * The default header strings are:
- * 
- * #define LOG_ERROR_HEAD "ERROR: "
- * #define LOG_WARN_HEAD "WARNING: "
- * #define LOG_INFO_HEAD "INFO: "
- * #define LOG_DEBUG_HEAD "DEBUG: "
- *
- * To use the macros, you must tell the pre-processor about your LogSerial instance.  To do this,
- * specify a #define for LOG_SERIAL_INST *before* including the LogSerial.h include file.
- * If LOG_SERIAL_INST is not defined, than these macros become empty statements in your sketch.
- * 
- * To use the LogSerial class and convenience macros (by default, the macros are empty):
- * 
- * 1) #define a LOG_SERIAL_INST *before* the Include.  It should point to your LogSerial instance.
- * 2) Define any "Log header string" overrides
- * 3) Include the LogSerial header file
- * 4) Create a LogSerial instance
- * 5) Call the begin method (with baudrate, or empty (default to 500k))
- * 6) Set your log level using setLogLevel method
- * 7) Call enable method to turn on log messaging
- * 8) Use the appropriate macros or print methods (either in LogSerial, or the ServicePortSerial class)
- * 
- * E.g. Using macros...
- * #define LOG_SERIAL_INST lsp
- * // Specify my own LOG_INFO header string
- * #define LOG_INFO_HEAD "[I]: "
- * 
- * #include "LogSerial.h"
- * 
- * LogSerial lsp;
- * 
- * LOGI("A somewhat informational format string: %s", F("Move along, nothing here"));
+Use your format string as-is:
+ LOG - Always log
+ LOGE - Log an error message
+ LOGW - Log a warning message
+ LOGI - Log an informational message
+ LOGD - Log a debug message
+ 
+Stores your format string in Flash memory:
+ LOGF - Always log
+ LOGEF - Log an error message
+ LOGWF - Log a warning message
+ LOGIF - Log an informational message
+ LOGDF - Log a debug message
+ 
+Simple use-case:
+
+// Only include error and warning log messages in compilation.
+// Information and Debug logging are compiled away.
+#define USE_LOG_LEVEL LOG_WARN
+
+#include "LogSerial.h"
+ 
+void setup() {
+  // Configure Serial Monitor for 500k baud
+  LOG_SERIAL_BEGIN(500000);
+}
+
+void loop() {
+  // Display error log in Serial Monitor
+  LOGEF("Yikes, error on line %d in %s\n", __LINE__, __FILE__);
+  // Informational message - compiled away if USE_LOG_LEVEL is below LOG_INFO
+  LOGIF("Millis=%lu Value=%x: It works! ", millis(), somevalue); 
+} 
+ 
+The header strings for the LOGx macros are customizable by defining your own value.
+The default header strings are:
+ 
+ #define LOG_ERROR_HEAD "ERROR: "
+ #define LOG_WARN_HEAD "WARNING: "
+ #define LOG_INFO_HEAD "INFO: "
+ #define LOG_DEBUG_HEAD "DEBUG: "
  */
 #ifndef LogSerial_h
 
 #define LogSerial_h
 
-
 #include "Serial.h"
 
-enum LogLevel { LOG_ERROR=0, LOG_WARN=1, LOG_INFO=2, LOG_DEBUG=3, LOG_ALL=4 };
+#define LOG_NONE    0
+#define LOG_ERROR   1
+#define LOG_WARN    2
+#define LOG_INFO    3
+#define LOG_DEBUG   4
+#define LOG_ALL     LOG_DEBUG
 
-/*
- * If you want Log capability, instantiate this class instead of ServicePortSerial.
- */
+#ifdef USE_LOG_LEVEL
+
+// Convenience for future
+#define LOG_SERIAL_PRINT_METHOD_NAME LogSerialPrint
+
 class LogSerial : public ServicePortSerial {
 
     public:
 
-    void begin();// defaults to 500k baud rate
-    void begin(unsigned long);// specify baud rate (250000 or 500000)
+    LogSerial(LogSerial const&) = delete;
+    void operator=(LogSerial const&) = delete;
 
-    void setLogLevel(LogLevel);
-    LogLevel getLogLevel();
- 
-    void enable();// enable logging
-    void disable();// disable logging
+    static void init();
+    static void init(unsigned long);// specify baud rate (250000 or 500000)
 
-    size_t print(LogLevel, const char *, ...);
-    size_t print(LogLevel, const __FlashStringHelper *, ...);
-
-    using Print::print;                     // pull in base print methods
+    static size_t LOG_SERIAL_PRINT_METHOD_NAME(const char *, ...);
+    static size_t LOG_SERIAL_PRINT_METHOD_NAME(const __FlashStringHelper *, ...);
 
     private:
 
-    bool shouldLog(LogLevel);
+    static LogSerial *getInstance() {
+        static LogSerial instance;
+        return &instance;
+    }
 
-    LogLevel logLevel = LogLevel::LOG_ERROR;
-    bool enabled = false;
+    LogSerial() {}
 };
-
-
-#ifdef LOG_SERIAL_INST
-
-// Users can override these header strings
-#ifndef LOG_ERROR_HEAD
-#define LOG_ERROR_HEAD "ERROR:  "
-#endif
-#ifndef LOG_WARN_HEAD
-#define LOG_WARN_HEAD "WARNING: "
-#endif
-#ifndef LOG_INFO_HEAD
-#define LOG_INFO_HEAD "INFO: "
-#endif
-#ifndef LOG_DEBUG_HEAD
-#define LOG_DEBUG_HEAD "DEBUG: "
 #endif
 
-// Use format string as-is
-#define LOG(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ALL, fmt, ##__VA_ARGS__))
-#define LOGE(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ERROR, (LOG_ERROR_HEAD fmt), ##__VA_ARGS__))
-#define LOGW(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_WARN, (LOG_WARN_HEAD fmt), ##__VA_ARGS__))
-#define LOGI(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_INFO, (LOG_INFO_HEAD fmt), ##__VA_ARGS__))
-#define LOGD(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_DEBUG, (LOG_DEBUG_HEAD fmt), ##__VA_ARGS__))
+#if (USE_LOG_LEVEL > 0)
 
-// Wrap the format string in F() macro
-#define LOGF(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ALL, F(fmt), ##__VA_ARGS__))
-#define LOGFE(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_ERROR, F(LOG_ERROR_HEAD fmt), ##__VA_ARGS__))
-#define LOGFW(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_WARN, F(LOG_WARN_HEAD fmt), ##__VA_ARGS__))
-#define LOGFI(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_INFO, F(LOG_INFO_HEAD fmt), ##__VA_ARGS__))
-#define LOGFD(fmt, ...) (LOG_SERIAL_INST.print(LogLevel::LOG_DEBUG, F(LOG_DEBUG_HEAD fmt), ##__VA_ARGS__))
+#define LOG_SERIAL_PRINT_METHOD LogSerial::LOG_SERIAL_PRINT_METHOD_NAME
+#define LOG(fmt, ...) (LOG_SERIAL_PRINT_METHOD(fmt, ##__VA_ARGS__))
+#define LOGF(fmt, ...) (LOG_SERIAL_PRINT_METHOD(F(fmt), ##__VA_ARGS__))
+#define LOG_SERIAL_BEGIN(baudrate) LogSerial::init(baudrate)
 
-#else // LOG_SERIAL_INST not defined
+#else // USE_LOG_LEVEL 0
 
 #define LOG(fmt, ...) (void(0))
-#define LOGE(fmt, ...) (void(0))
-#define LOGW(fmt, ...) (void(0))
-#define LOGI(fmt, ...) (void(0))
-#define LOGD(fmt, ...) (void(0))
-
 #define LOGF(fmt, ...) (void(0))
-#define LOGFE(fmt, ...) (void(0))
-#define LOGFW(fmt, ...) (void(0))
-#define LOGFI(fmt, ...) (void(0))
-#define LOGFD(fmt, ...) (void(0))
+#define LOG_SERIAL_BEGIN(baudrate) (void(0))
+#undef LOG_SERIAL_PRINT_METHOD_NAME
 
-#endif // LOG_SERIAL_INST
+#endif // USE_LOG_LEVEL defined at all
+
+#if (USE_LOG_LEVEL >= LOG_ERROR)
+
+    #ifndef LOG_ERROR_HEAD
+    // Users can override these header strings
+    #define LOG_ERROR_HEAD "ERROR:  "
+    #endif
+
+    // #pragma message "Including ERROR logging"
+    #define LOGE(fmt, ...) (LOG_SERIAL_PRINT_METHOD((LOG_ERROR_HEAD fmt), ##__VA_ARGS__))
+    #define LOGEF(fmt, ...) (LOG_SERIAL_PRINT_METHOD(F(LOG_ERROR_HEAD fmt), ##__VA_ARGS__))
+
+#else // Not including errors
+
+    #define LOGE(fmt, ...) (void(0))
+    #define LOGEF(fmt, ...) (void(0))
+
+#endif // Error macros
+
+#if (USE_LOG_LEVEL >= LOG_WARN)
+
+    #ifndef LOG_WARN_HEAD
+    // Users can override these header strings
+    #define LOG_WARN_HEAD "WARNING: "
+    #endif
+
+    // #pragma message "Including WARN logging"
+    #define LOGW(fmt, ...) (LOG_SERIAL_PRINT_METHOD((LOG_WARN_HEAD fmt), ##__VA_ARGS__))
+    #define LOGWF(fmt, ...) (LOG_SERIAL_PRINT_METHOD(F(LOG_WARN_HEAD fmt), ##__VA_ARGS__))
+
+#else // Not including warnings
+
+    #define LOGW(fmt, ...) (void(0))
+    #define LOGWF(fmt, ...) (void(0))
+#endif
+
+#if (USE_LOG_LEVEL >= LOG_INFO)
+
+    #ifndef LOG_INFO_HEAD
+    // Users can override these header strings
+    #define LOG_INFO_HEAD "INFO: "
+    #endif
+
+    // #pragma message "Including INFO logging"
+    #define LOGI(fmt, ...) (LOG_SERIAL_PRINT_METHOD((LOG_INFO_HEAD fmt), ##__VA_ARGS__))
+    #define LOGIF(fmt, ...) (LOG_SERIAL_PRINT_METHOD(F(LOG_INFO_HEAD fmt), ##__VA_ARGS__))
+
+#else // Not including info
+
+    #define LOGI(fmt, ...) (void(0))
+    #define LOGIF(fmt, ...) (void(0))
 
 #endif
+
+#if (USE_LOG_LEVEL >= LOG_DEBUG)
+
+    #ifndef LOG_DEBUG_HEAD
+    // Users can override these header strings
+    #define LOG_DEBUG_HEAD "DEBUG: "
+    #endif
+
+    // #pragma message "Including DEBUG logging"
+    #define LOGD(fmt, ...) (LOG_SERIAL_PRINT_METHOD((LOG_DEBUG_HEAD fmt), ##__VA_ARGS__))
+    #define LOGDF(fmt, ...) (LOG_SERIAL_PRINT_METHOD(F(LOG_DEBUG_HEAD fmt), ##__VA_ARGS__))
+
+#else // not including debug messages
+
+    #define LOGD(fmt, ...) (void(0))
+    #define LOGDF(fmt, ...) (void(0))
+
+#endif
+
+#endif // end include file guard

--- a/libraries/blinklib/src/LogSerial.h
+++ b/libraries/blinklib/src/LogSerial.h
@@ -79,10 +79,11 @@ The default header strings are:
 #define LOG_DEBUG   4
 #define LOG_ALL     LOG_DEBUG
 
-#ifdef USE_LOG_LEVEL
-
-// Convenience for future
-#define LOG_SERIAL_PRINT_METHOD_NAME LogSerialPrint
+// ensure only chooses what's supported.
+enum SerialMonitorBaudRate {
+    SM_BAUD_RATE_500K = 500000,
+    SM_BAUD_RATE_250K = 250000
+};
 
 class LogSerial : public ServicePortSerial {
 
@@ -91,11 +92,11 @@ class LogSerial : public ServicePortSerial {
     LogSerial(LogSerial const&) = delete;
     void operator=(LogSerial const&) = delete;
 
-    static void init();
-    static void init(unsigned long);// specify baud rate (250000 or 500000)
+   static void init(SerialMonitorBaudRate);// specify baud rate (250000 or 500000)
 
-    static size_t LOG_SERIAL_PRINT_METHOD_NAME(const char *, ...);
-    static size_t LOG_SERIAL_PRINT_METHOD_NAME(const __FlashStringHelper *, ...);
+
+    static size_t LogSerialPrint(const char *, ...);
+    static size_t LogSerialPrint(const __FlashStringHelper *, ...);
 
     private:
 
@@ -106,21 +107,20 @@ class LogSerial : public ServicePortSerial {
 
     LogSerial() {}
 };
-#endif
 
 #if (USE_LOG_LEVEL > 0)
 
-#define LOG_SERIAL_PRINT_METHOD LogSerial::LOG_SERIAL_PRINT_METHOD_NAME
+
+#define LOG_SERIAL_PRINT_METHOD LogSerial::LogSerialPrint
 #define LOG(fmt, ...) (LOG_SERIAL_PRINT_METHOD(fmt, ##__VA_ARGS__))
 #define LOGF(fmt, ...) (LOG_SERIAL_PRINT_METHOD(F(fmt), ##__VA_ARGS__))
-#define LOG_SERIAL_BEGIN(baudrate) LogSerial::init(baudrate)
+#define LOG_SERIAL_BEGIN(enumbaudrate) LogSerial::init(enumbaudrate)
 
 #else // USE_LOG_LEVEL 0
 
 #define LOG(fmt, ...) (void(0))
 #define LOGF(fmt, ...) (void(0))
-#define LOG_SERIAL_BEGIN(baudrate) (void(0))
-#undef LOG_SERIAL_PRINT_METHOD_NAME
+#define LOG_SERIAL_BEGIN(enumbaudrate) (void(0))
 
 #endif // USE_LOG_LEVEL defined at all
 

--- a/libraries/blinklib/src/LogSerial.h
+++ b/libraries/blinklib/src/LogSerial.h
@@ -156,13 +156,13 @@ class LogSerial : public ServicePortSerial {
 
 #else // LOG_SERIAL_INST not defined
 
-#define LOGA(fmt, ...) (void(0))
+#define LOG(fmt, ...) (void(0))
 #define LOGE(fmt, ...) (void(0))
 #define LOGW(fmt, ...) (void(0))
 #define LOGI(fmt, ...) (void(0))
 #define LOGD(fmt, ...) (void(0))
 
-#define LOGFA(fmt, ...) (void(0))
+#define LOGF(fmt, ...) (void(0))
 #define LOGFE(fmt, ...) (void(0))
 #define LOGFW(fmt, ...) (void(0))
 #define LOGFI(fmt, ...) (void(0))


### PR DESCRIPTION
(Copy/paste partial from LogSerial.h comment)
---
Summary of LogSerial functionality:

Supports a "printf" style formatting (fprintf) with a variable number of arguments.  
Simple setup and access to logging via macros (i.e. implementation detail knowledge not required)
Provides five increasing log levels: LOG_NONE, LOG_ERROR, LOG_WARN, LOG_INFO, LOG_DEBUG (or LOG_ALL).
Customizable header string per macro type.
Log messages can be compiled away at graduated log levels (reducing sketch size for non-debug compilation)
All LogSerial functionality can be compiled away with a single line change.
Can store formats string in Flash memory (efficient space saving).
Supports either 250k or 500k (default) baud rate for the Serial Monitor port. (VSCode max is 250k)

Note: LogSerial does not preclude the use of the ServicePortSerial class or methods.  
However, to realize the above benefits, users should transition to using LogSerial. 

To use LogSerial functionality:
 1) Define a USE_LOG_LEVEL and value at the beginning of your sketch (before the Include file).
 2) Include "LogSerial.h"
 3) Call the LOG_SERIAL_BEGIN macro in your setup method (with baudrate, or empty (default to 500k))
 4) Use the appropriate LogSerial macro's

Defining USE_LOG_LEVEL (examples):
To include all log levels, define USE_LOG_LEVEL to LOG_DEBUG (or LOG_ALL).
To only include errors, set USE_LOG_LEVEL to LOG_ERROR.  (All other log messages are compiled away.)
To only include errors and warnings, set USE_LOG_LEVEL to LOG_WARN. (Info and Debug log messages are compiled away.)
To compile away all LogSerial macros, either do not define USE_LOG_LEVEL or set its value to LOG_NONE.

LogSerial Macros:
The LogSerial macro composition: 
  // macroName( formatString, variableArgs)
  LOGx ( formatString, ...)

There are 2 sets of macros;
 
Use your format string as-is:
 LOG - Always log
 LOGE - Log an error message
 LOGW - Log a warning message
 LOGI - Log an informational message
 LOGD - Log a debug message
 
Stores your format string in Flash memory (Note, 'F' at end of Macro name):
 LOGF - Always log
 LOGEF - Log an error message
 LOGWF - Log a warning message
 LOGIF - Log an informational message
 LOGDF - Log a debug message

// My sketch - can use LogSerial w/o needing to know implementation
// To compile in only ERRORs and WARNINGs
#define USE_LOG_LEVEL LOG_WARN

#include "LogSerial.h"

void setup() {
  LOG_SERIAL_BEGIN();
}

void loop() {
...
LOGEF("[%lu] Starting value was %d, should've been %d\n", millis(), newValue, origValue);
...
// Info message (compiled away unless USE_LOG_LEVEL is at least LOG_INFO)
LOGIF("Message received: %s [%x]\n", newMessage, hexValue);
}