### PR TITLE
Improve IR reliability on blinks dev kits with silicone covers 

### DIFF
--- a/AS7/blink/Sketches/Blink/main.cpp
+++ b/AS7/blink/Sketches/Blink/main.cpp
@@ -20,11 +20,12 @@ static void clearErrors() {
 void setup() {
   // put your setup code here, to run once:
   clearErrors();
-             SP_PIN_A_MODE_OUT();
-             sp_serial_init();
-             sp_serial_disable_rx();
-             SP_PIN_R_MODE_OUT();
-             sp_serial_tx('h');
+  
+    SP_PIN_A_MODE_OUT();
+    sp_serial_init();
+    sp_serial_disable_rx();
+    SP_PIN_R_MODE_OUT();
+    sp_serial_tx('h');
 
 }
 
@@ -124,34 +125,22 @@ long map_m(long x, long in_min, long in_max, long out_min, long out_max)
 // Breaks if (myState_count^2) > IR_DATA_VALUE_MAX
 
 byte encode( byte v ) {
-
-    byte inverted =  ( myState_count -1 -v ) ;
-
-    byte invertedTruncated = inverted % 8;
-
-    return( v + ( invertedTruncated * myState_count) );
+    
+    return v | ( (~v) <<4 ); 
 
 }
 
 byte decode( byte v ) {
 
-    return( v % myState_count );
+    return v & 0x0f;
 
 }
 
 
 byte test( byte v ) {
-
-    byte orginal = decode( v ) ;
-
-    byte inverted =  ( myState_count -1 - orginal ) ;
-
-    byte calculatedInvertedTruncated = inverted % 8;
-
-    byte recoveredInvertedTruncated = v / myState_count ;
-
-    return calculatedInvertedTruncated == recoveredInvertedTruncated;
-
+        
+    return ( v & 0x0f ) == ( ( (~v) >> 4 ) & 0x0f) ;
+    
 }
 
 
@@ -210,6 +199,9 @@ void loop() {
 //  setValueSentOnAllFaces( 0b11110000 );         // TESTING
 //  setValueSentOnAllFaces( 0b11110001 );         // TESTING
 
-  setValueSentOnAllFaces( encode( myState ) );
+  byte s = encode( myState); 
+  
+ //  setValueSentOnAllFaces( encode( myState ) );
+  setValueSentOnAllFaces( s );
 
 }

--- a/AS7/blink/Sketches/Blink/main.cpp
+++ b/AS7/blink/Sketches/Blink/main.cpp
@@ -126,20 +126,20 @@ long map_m(long x, long in_min, long in_max, long out_min, long out_max)
 
 byte encode( byte v ) {
     
-    return v | ( (~v) <<4 ); 
+    return v | ( (v % 2) <<3 ); 
 
 }
 
 byte decode( byte v ) {
 
-    return v & 0x0f;
+    return v & 0b00000111;
 
 }
 
 
 byte test( byte v ) {
         
-    return ( v & 0x0f ) == ( ( (~v) >> 4 ) & 0x0f) ;
+    return ( (decode( v ) % 2 ) == (  v >> 3 ) ) ;
     
 }
 

--- a/AS7/blink/blinklib/blinklib.cppproj
+++ b/AS7/blink/blinklib/blinklib.cppproj
@@ -104,65 +104,65 @@
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
     <ToolchainSettings>
       <AvrGccCpp>
-        <avrgcc.common.Device>-mmcu=atmega168pb -B "%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\gcc\dev\atmega168pb"</avrgcc.common.Device>
-        <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
-        <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
-        <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
-        <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
-        <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
-        <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
-        <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
-        <avrgcc.compiler.symbols.DefSymbols>
-          <ListValues>
-            <Value>DEBUG</Value>
-          </ListValues>
-        </avrgcc.compiler.symbols.DefSymbols>
-        <avrgcc.compiler.directories.IncludePaths>
-          <ListValues>
-            <Value>../../../../variants/standard</Value>
-            <Value>../../../../cores/blinkcore</Value>
-            <Value>../../../../libraries/blinklib/src</Value>
-            <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\include</Value>
-          </ListValues>
-        </avrgcc.compiler.directories.IncludePaths>
-        <avrgcc.compiler.optimization.level>Optimize (-O1)</avrgcc.compiler.optimization.level>
-        <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
-        <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
-        <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
-        <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
-        <avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>
-        <avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>
-        <avrgcccpp.compiler.symbols.DefSymbols>
-          <ListValues>
-            <Value>DEBUG</Value>
-          </ListValues>
-        </avrgcccpp.compiler.symbols.DefSymbols>
-        <avrgcccpp.compiler.directories.IncludePaths>
-          <ListValues>
-            <Value>../../../../cores/blinkcore</Value>
-            <Value>../../../../variants/standard</Value>
-            <Value>../../../../libraries/blinklib/src</Value>
-            <Value>../../../../libraries/blinkstate/src</Value>
-            <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\include</Value>
-          </ListValues>
-        </avrgcccpp.compiler.directories.IncludePaths>
-        <avrgcccpp.compiler.optimization.level>Optimize (-O1)</avrgcccpp.compiler.optimization.level>
-        <avrgcccpp.compiler.optimization.PackStructureMembers>True</avrgcccpp.compiler.optimization.PackStructureMembers>
-        <avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>
-        <avrgcccpp.compiler.optimization.DebugLevel>Default (-g2)</avrgcccpp.compiler.optimization.DebugLevel>
-        <avrgcccpp.compiler.warnings.AllWarnings>True</avrgcccpp.compiler.warnings.AllWarnings>
-        <avrgcccpp.linker.libraries.Libraries>
-          <ListValues>
-            <Value>libm</Value>
-          </ListValues>
-        </avrgcccpp.linker.libraries.Libraries>
-        <avrgcccpp.assembler.general.IncludePaths>
-          <ListValues>
-            <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\include</Value>
-          </ListValues>
-        </avrgcccpp.assembler.general.IncludePaths>
-        <avrgcccpp.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcccpp.assembler.debugging.DebugLevel>
-      </AvrGccCpp>
+  <avrgcc.common.Device>-mmcu=atmega168pb -B "%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\gcc\dev\atmega168pb"</avrgcc.common.Device>
+  <avrgcc.common.outputfiles.hex>True</avrgcc.common.outputfiles.hex>
+  <avrgcc.common.outputfiles.lss>True</avrgcc.common.outputfiles.lss>
+  <avrgcc.common.outputfiles.eep>True</avrgcc.common.outputfiles.eep>
+  <avrgcc.common.outputfiles.srec>True</avrgcc.common.outputfiles.srec>
+  <avrgcc.common.outputfiles.usersignatures>False</avrgcc.common.outputfiles.usersignatures>
+  <avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcc.compiler.general.ChangeDefaultCharTypeUnsigned>
+  <avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcc.compiler.general.ChangeDefaultBitFieldUnsigned>
+  <avrgcc.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>DEBUG</Value>
+    </ListValues>
+  </avrgcc.compiler.symbols.DefSymbols>
+  <avrgcc.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>../../../../variants/standard</Value>
+      <Value>../../../../cores/blinkcore</Value>
+      <Value>../../../../libraries/blinklib/src</Value>
+      <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\include</Value>
+    </ListValues>
+  </avrgcc.compiler.directories.IncludePaths>
+  <avrgcc.compiler.optimization.level>Optimize most (-O3)</avrgcc.compiler.optimization.level>
+  <avrgcc.compiler.optimization.PackStructureMembers>True</avrgcc.compiler.optimization.PackStructureMembers>
+  <avrgcc.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcc.compiler.optimization.AllocateBytesNeededForEnum>
+  <avrgcc.compiler.optimization.DebugLevel>Default (-g2)</avrgcc.compiler.optimization.DebugLevel>
+  <avrgcc.compiler.warnings.AllWarnings>True</avrgcc.compiler.warnings.AllWarnings>
+  <avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultCharTypeUnsigned>
+  <avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>True</avrgcccpp.compiler.general.ChangeDefaultBitFieldUnsigned>
+  <avrgcccpp.compiler.symbols.DefSymbols>
+    <ListValues>
+      <Value>DEBUG</Value>
+    </ListValues>
+  </avrgcccpp.compiler.symbols.DefSymbols>
+  <avrgcccpp.compiler.directories.IncludePaths>
+    <ListValues>
+      <Value>../../../../cores/blinkcore</Value>
+      <Value>../../../../variants/standard</Value>
+      <Value>../../../../libraries/blinklib/src</Value>
+      <Value>../../../../libraries/blinkstate/src</Value>
+      <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\include</Value>
+    </ListValues>
+  </avrgcccpp.compiler.directories.IncludePaths>
+  <avrgcccpp.compiler.optimization.level>Optimize (-O1)</avrgcccpp.compiler.optimization.level>
+  <avrgcccpp.compiler.optimization.PackStructureMembers>True</avrgcccpp.compiler.optimization.PackStructureMembers>
+  <avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>True</avrgcccpp.compiler.optimization.AllocateBytesNeededForEnum>
+  <avrgcccpp.compiler.optimization.DebugLevel>Default (-g2)</avrgcccpp.compiler.optimization.DebugLevel>
+  <avrgcccpp.compiler.warnings.AllWarnings>True</avrgcccpp.compiler.warnings.AllWarnings>
+  <avrgcccpp.linker.libraries.Libraries>
+    <ListValues>
+      <Value>libm</Value>
+    </ListValues>
+  </avrgcccpp.linker.libraries.Libraries>
+  <avrgcccpp.assembler.general.IncludePaths>
+    <ListValues>
+      <Value>%24(PackRepoDir)\atmel\ATmega_DFP\1.2.209\include</Value>
+    </ListValues>
+  </avrgcccpp.assembler.general.IncludePaths>
+  <avrgcccpp.assembler.debugging.DebugLevel>Default (-Wa,-g)</avrgcccpp.assembler.debugging.DebugLevel>
+</AvrGccCpp>
     </ToolchainSettings>
   </PropertyGroup>
   <ItemGroup>

--- a/cores/blinkcore/Timers.md
+++ b/cores/blinkcore/Timers.md
@@ -1,0 +1,16 @@
+# Blinks Timer Usage
+
+The ATMEGA168PB has 3 hardware timers. We use them all. 
+
+## `TIMER0`
+
+The hardware outputs of this timer directly drive the cathodes of the red and green LEDs.
+
+## `TIMER1`
+
+Used to precisely time the IR transmit pulses. Software only, no hardware connections.
+
+## `TIMER2`
+
+One hardware output is used to drive the blue LED charge pump. It also has a match set 1/2 way though the phase to drive the IR receive ISR out of phase with the `TIMER0` ISR.
+

--- a/cores/blinkcore/ir.cpp
+++ b/cores/blinkcore/ir.cpp
@@ -42,7 +42,7 @@
 // Having the charge time too long is not a big concern since one it is fully charged that's it. Maybe the only concern is that it can not receive
 // a new pulse while charging, so you might mask an RX if the total of the charge time and everything else is longer than the time between pulses (including clock skew).
 
-#define IR_CHARGE_TIME_US 4         // How long to charge the LED though the pull-up
+#define IR_CHARGE_TIME_US 10         // How long to charge the LED though the pull-up
 
 #define IR_PULSE_TIME_US 10         // How long to turn IR LED on to send a pulse
 

--- a/cores/blinkcore/ir.cpp
+++ b/cores/blinkcore/ir.cpp
@@ -56,22 +56,7 @@
 
 #endif
 
-
-// If defined, TX_DEBUG will output HIGH on pin A on a Dev Candy board anytime
-// an IR pulse is sent on IR0. The pulse is high for the duration of the IR on time.
-
-//#define TX_DEBUG
-
-
-// If defined, RX_DEBUG will output HIGH on pin A on a dev candy board anytime
-// an IR pulse is received on IR0. The pulse is high from the moment the pin changes,
-// to the moment it is read by the timer polling routine.
-// The ServicePort serial will transmit at 1Mpbs the follwoing...
-// 'I' on startup initialization
-//
-
-#define RX_DEBUG
-
+// Debug flags can be uncommented in ir.h
 
 #if defined ( TX_DEBUG )  || defined ( RX_DEBUG ) || defined (IR_DEBUG)
 

--- a/cores/blinkcore/ir.cpp
+++ b/cores/blinkcore/ir.cpp
@@ -70,7 +70,7 @@
 // 'I' on startup initialization
 //
 
-//#define RX_DEBUG
+#define RX_DEBUG
 
 
 #if defined ( TX_DEBUG )  || defined ( RX_DEBUG ) || defined (IR_DEBUG)

--- a/cores/blinkcore/ir.h
+++ b/cores/blinkcore/ir.h
@@ -30,6 +30,11 @@
 #define RX_DEBUG
 
 
+// If defined, we keep some extra error counters for diagnostics. 
+// Otherwise IR errors don't really show up anywhere except maybe decreased performance. 
+// TODO: Implement these counters so we have a way of seeing errors. 
+//#define RX_TRACK_ERRORS
+
 #define IRLED_COUNT FACE_COUNT
 
 #define IR_ALL_BITS (0b00111111)        // All six IR LEDs

--- a/cores/blinkcore/ir.h
+++ b/cores/blinkcore/ir.h
@@ -43,20 +43,18 @@ void ir_enable(void);
 void ir_disable(void);
 
 // Sends starting a pulse train.
-// Each pulse will have an integer number of delays between it and the previous pulse.
-// Each of those delay windows is spacing_ticks wide.
-// This sets things up and sends the initial pulse.
+// Will send first pulse and then wait initialTicks before sending second pulse.
 // Then continue to call ir_tx_sendpulse() to send subsequent pulses
 // Call ir_tx_end() after last pulse to turn off the ISR (optional but saves CPU and power)
 
-void ir_tx_start(uint16_t spacing_ticks , uint8_t bitmask , uint16_t initialSpaces );
-
+void ir_tx_start(uint8_t bitmask , uint16_t initialTicks );
+    
 // Send next pulse int this pulse train.
 // leadingSpaces is the number of spaces to wait between the previous pulse and this pulse.
 // 0 doesn't really make any sense
 // Note that you must called ir_tx_sendpuse fast enough that the buffer doesn't run dry
 
-void ir_tx_sendpulse( uint8_t leadingSpaces );
+void ir_tx_sendpulse( uint16_t delay_cycles);
 
 // Turn off the pulse sending ISR
 // Blocks until final pulse transmitted

--- a/cores/blinkcore/ir.h
+++ b/cores/blinkcore/ir.h
@@ -14,15 +14,21 @@
 // These #defines will let you see what is happening on the IR link by connecting an
 // oscilloscope to the service port pins.
 
-// #define TX_DEBUG
-// Pin A will go high when IR pulse sent on IR0
+// If defined, TX_DEBUG will output HIGH on pin A on a Dev Candy board anytime
+// an IR pulse is sent on IR0. The pulse is high for the duration of the IR on time.
+
+//#define TX_DEBUG
+
+
+// If defined, RX_DEBUG will output HIGH on pin A on a dev candy board anytime
+// an IR pulse is received on IR0. The pulse is high from the moment the pin changes,
+// to the moment it is read by the timer polling routine.
+// The ServicePort serial will transmit at 1Mpbs the following...
+// 'I' on startup initialization
+//
 
 #define RX_DEBUG
-// Pin A will go high when IR0 is triggered (the charge is drained by light hitting the LED). Note this is dependent on interrupts being on. In ir.cpp
-// Pin R will go high during each sample window. In ir.cpp
-// You might think you could just put a scope on the LED pin and watch it directly, but the resistance of the probe kills the effect so
-// we have to do it in software. The input pin has very, very high impedance.
-// TX will send chars based on the receive state of IR0. Look in irdata.cpp to see what they are.
+
 
 #define IRLED_COUNT FACE_COUNT
 

--- a/cores/blinkcore/ir.h
+++ b/cores/blinkcore/ir.h
@@ -67,13 +67,7 @@ void ir_tx_end(void);
 // Returns a 1 in each bit for each LED that was fired.
 // Fired LEDs are recharged.
 
-uint8_t ir_sample_bits( void );
-
-// Charge the bits set to 1 in 'chargeBits'
-// Probably best to call with ints off so doesn't get interrupted
-// Probably best to call some time after ir_sample_bits() so that a long pulse will not be seen twice.
-
-void ir_charge_LEDs( uint8_t chargeBits );
+uint8_t ir_sample_and_charge_LEDs();
 
 
 #define WAKEON_IR_BITMASK_NONE     0             // Don't wake on any IR change

--- a/cores/blinkcore/pixel.cpp
+++ b/cores/blinkcore/pixel.cpp
@@ -463,7 +463,7 @@ static void pixel_isr(void) {
             // If the blue led is on for this pixel, then in the previous phase we
             // enabled the sink and connected the PWM pin.
 
-            // Now we blinkly disable the sink since we don't want it anymore no matter what
+            // Now we blindly disable the sink since we don't want it anymore no matter what
 
             CBI( BLUE_SINK_DDR , BLUE_SINK_BIT);    // Turn off blue sink (make it input) if we were charging
                                                     // Might already be off, but faster to blindly turn off again rather than test
@@ -473,14 +473,14 @@ static void pixel_isr(void) {
 
             // Now the sink is off, we are safe to activate the anode.
             // Remember that the PWM pin is still high and connected if there is blue in this pixel.
-            // A little current will flow now though the capactor, but that ok.
+            // A little current will flow now though the capacitor, but that ok.
             // when the PWM goes low, then the boost will kick in and make the BLUE really light
 
             activateAnode( currentPixelIndex );
 
             // Ok, now we are ready for all the PWMing to happen on this pixel
 
-            // Load up the blue PWM to go low and show blue (if the pump and PWM were activeated in phase #0)....
+            // Load up the blue PWM to go low and show blue (if the pump and PWM were activated in phase #0)....
 
             OCR2B=currentPixel->rawValueB;             // Load OCR to turn on blue at next overflow
 
@@ -506,7 +506,7 @@ static void pixel_isr(void) {
             // We are now done with BLUE, so we need to disconnect it to avoid
             // dimly lighting the next LED.
 
-            // TODO: Pushg this forward a phase for more brightness?
+            // TODO: Push this forward a phase for more brightness?
 
             // Float the BLUE LED drive pin.
             // This cuts off a path for current though the pump cap
@@ -527,8 +527,7 @@ static void pixel_isr(void) {
             TCCR2A =
               _BV( WGM01) | _BV( WGM00);             // Mode 3 - Fast PWM TOP=0xFF
 
-            // BLue LED is no completely disconnected form everything so should be off.
-
+            // BLue LED is now completely disconnected form everything so should be off.
 
             OCR0A = 255;                        // Load OCR to turn off red at next overflow
             OCR0B = currentPixel->rawValueG;    // Load OCR to turn on green at next overflow
@@ -606,6 +605,8 @@ static void pixelTimerOff(void) {
 }
 
 
+
+
 // Called when Timer0 overflows, which happens at the end of the PWM cycle for each pixel. We advance to the next pixel.
 
 // This fires every 500us (2Khz)
@@ -629,7 +630,7 @@ ISR(TIMER0_OVF_vect)
 
     pixel_isr();
 
-    timer_128us_callback_sei();       // Do the doubletime callback
+    timer_128us_callback_sei();       // Do the double-time callback
     timer_256us_callback_sei();       // Do everything else non-timing sensitive.
     return;
 }

--- a/libraries/blinklib/src/blinklib.cpp
+++ b/libraries/blinklib/src/blinklib.cpp
@@ -303,7 +303,7 @@ static volatile uint8_t maxCompletedClickCount=0;       // Remember the most com
 
 
 static volatile uint8_t buttonChangeFlag = 1;           // Set anytime the button changes state. Used to reset the sleep timer in the foreground.
-                                                        // Init to 1 so that we reset the sleep timer on startup. 
+                                                        // Init to 1 so that we reset the sleep timer on startup.
 
 // Called once per tick by the timer to check the button position
 // and update the button state variables.
@@ -660,7 +660,7 @@ void timer_256us_callback_sei(void) {
 // This is called by timer ISR about every 256us with interrupts on.
 
 void timer_128us_callback_sei(void) {
-    updateIRComs();
+    IrDataPeriodicUpdateComs();
 }
 
 // This is the entry point where the blinkcore platform will pass control to

--- a/libraries/blinklib/src/blinklib.h
+++ b/libraries/blinklib/src/blinklib.h
@@ -74,7 +74,7 @@ bool buttonLongPressed(void);
 // Send data on a single face.
 // Data is 6-bits wide, top bits are ignored.
 
-void irSendData( uint8_t face , uint8_t data   );
+void irSendData( uint8_t face , const uint8_t *data , uint8_t len  );
 
 // Simultaneously send data on all faces that have a `1` in bitmask
 // Data is 6-bits wide, top bits are ignored.
@@ -259,9 +259,6 @@ byte getSerialNumberByte( byte n );
 
 */
 
-// Send data on a single face. Data is 6-bits wide (0-63 value).
-
-void irSendDataBitmask( uint8_t face , uint8_t data );
 
 // Broadcast data on all faces. Data is 6-bits wide (0-63 value).
 

--- a/libraries/blinklib/src/irdata.cpp
+++ b/libraries/blinklib/src/irdata.cpp
@@ -288,11 +288,13 @@ volatile uint8_t most_recent_ir_test;
                             if (bitwalker==0x01) {
                                 SP_SERIAL_TX_NOW('C');      // Complete byte
                                 sp_serial_tx( data );
-
+/*
                                 if ( !debug::test( data ) ) {
                                     SP_PIN_A_SET_1();               // SP pin A goes high any time IR0 is triggered. We clear it when we later process in the polling code.
                                     SP_PIN_A_SET_0();
                                 }
+                                
+*/                                
                             }
                         #endif
 
@@ -514,6 +516,7 @@ void irSendDataPacket(uint8_t bitmask, const uint8_t *packetBuffer, uint8_t len 
         } while (bitwalker);        // 1 bit overflows off top. Would be better if we could test for overflow bit
         
         packetBuffer++;
+        
         len--;
         
     }        
@@ -528,14 +531,10 @@ void irSendDataPacket(uint8_t bitmask, const uint8_t *packetBuffer, uint8_t len 
 // Send data on specified face
 // I put destination (face) first to mirror the stdio.h functions like fprintf().
 
-void irSendData(  uint8_t face , uint8_t data  ) {
+void irSendData(  uint8_t face , const uint8_t *data , uint8_t len ) {
+       
+    irSendDataPacket( 1 << face  , data , len );
     
-    uint8_t packetBuffer[2];
-    
-    packetBuffer[0]=data;
-    packetBuffer[1]=~data;
-    
-    irSendDataPacket( 1 << face  , packetBuffer , 2 );
 }
 
 

--- a/libraries/blinklib/src/irdata.cpp
+++ b/libraries/blinklib/src/irdata.cpp
@@ -131,10 +131,10 @@ struct ir_rx_state_t {
 
     Note that the byteBuffer will never be 0 if we are currently reading in a packet. This is because we stuff a 1 bit in the top slot when we start a valid byte reception.
     This makes the byteBuffer a good flag to see if we are currently receiving, and setting byteBuffer to 0 will abort anything in progress and wait for next SYNC.
-    
-    Note that a packet must be at least 1 byte long, or else we would see two syncs in a row as a zero byte packet. This is valid, but would waste the buffer until the 
+
+    Note that a packet must be at least 1 byte long, or else we would see two syncs in a row as a zero byte packet. This is valid, but would waste the buffer until the
     zero byte packet was marked as read. Byte requiring at least 1 good byte, we add the constraint that there must be at least 8 (or multipule of 8) will formed bits
-    between the syncs, which greatly increases error rejection. 
+    between the syncs, which greatly increases error rejection.
 
  */
 
@@ -167,9 +167,9 @@ volatile uint8_t most_recent_ir_test;
 
 
         inline byte test( byte v ) {
-    
+
             return ( v & 0x0f ) == ( ( (~v) >> 4 ) & 0x0f) ;
-    
+
         }
 
     }
@@ -270,7 +270,7 @@ volatile uint8_t most_recent_ir_test;
                         if ( ptr->packetBufferLen < IR_RX_PACKET_SIZE ) { // Check that there is room in the buffer to store this byte
 
                             ptr->packetBuffer[ptr->packetBufferLen] = data;
-                            
+
                             ptr->packetBufferLen++;
 
                             ptr->byteBuffer = 0b10000000;            // prime buffer for next byte to come in. Remember this 1 will fall off the bottomm after 8 bits to indicate a full byte
@@ -293,8 +293,8 @@ volatile uint8_t most_recent_ir_test;
                                     SP_PIN_A_SET_1();               // SP pin A goes high any time IR0 is triggered. We clear it when we later process in the polling code.
                                     SP_PIN_A_SET_0();
                                 }
-                                
-*/                                
+
+*/
                             }
                         #endif
 
@@ -325,32 +325,32 @@ volatile uint8_t most_recent_ir_test;
                     // since packets should always contain full bytes between the SYNCs
 
                     if (ptr->packetBufferLen) {
-                        
+
                         // Only save non-zero length packets because otherwise we would see two consecutive syncs
-                        // as a zero byte packet and there is just not enough error rejection, so a waste to use up 
-                        // the buffer on these. 
-                        
+                        // as a zero byte packet and there is just not enough error rejection, so a waste to use up
+                        // the buffer on these.
+
                         ptr->packetBufferReady = 1;     // Signal to the foreground that there is data ready in the packet buffer
-                        ptr->byteBuffer =0;             // stop reading until we get a new sync 
-                        
+                        ptr->byteBuffer =0;             // stop reading until we get a new sync
+
                         #ifdef RX_DEBUG
                             if (bitwalker==0x01) {
                                 SP_SERIAL_TX_NOW('R');      // sYnc
                                 sp_serial_tx( ptr->packetBufferLen );
-                            }                                
-                        #endif                        
-                        
+                            }
+                        #endif
+
                     } else {
-                        
+
                         // Got a sync, but nothing in packet buffer so treat it as a starting sync
                         // We are already reading so don't need to reset anything
 
                         #ifdef RX_DEBUG
                             if (bitwalker==0x01) {
                                 SP_SERIAL_TX_NOW('y');      // sYnc
-                            }                                                             
+                            }
                         #endif
-                    }                        
+                    }
 
 
                 } else {
@@ -487,18 +487,18 @@ void irSendDataPacket(uint8_t bitmask, const uint8_t *packetBuffer, uint8_t len 
     // RX LED is starting up charged when the leading pulse of the sync comes in.
     // We don't need to worry about that 1 getting seen as a real bit since the sync comes after it
     // and a long idle window came before it.
-    
-    // TODO: Slightly faster to send a 1-bit here rather than a sync. 
-    
-    ir_tx_start( bitmask , US_TO_CYCLES(  MIN_DELAY_LT( IR_TX_S_BIT_DELAY_RT_US , IR_CLOCK_SPREAD_PCT ))  );
-    
+
+    // TODO: Slightly faster to send a 1-bit here rather than a sync.
+
+    ir_tx_start( bitmask , US_TO_CYCLES(  MIN_DELAY_LT( IR_TX_1_BIT_DELAY_RT_US , IR_CLOCK_SPREAD_PCT ))  );
+
     ir_tx_sendpulse( US_TO_CYCLES(  MIN_DELAY_LT( IR_TX_S_BIT_DELAY_RT_US , IR_CLOCK_SPREAD_PCT ))  ) ;
 
 
     while (len) {
 
         uint8_t bitwalker = 0b00000001;
-        
+
         uint8_t currentByte = *packetBuffer;
 
         do {
@@ -510,16 +510,16 @@ void irSendDataPacket(uint8_t bitmask, const uint8_t *packetBuffer, uint8_t len 
             }
 
             bitwalker<<=1;
-            
+
             // TODO: Faster to do in ASM and check carry bit?
 
         } while (bitwalker);        // 1 bit overflows off top. Would be better if we could test for overflow bit
-        
+
         packetBuffer++;
-        
+
         len--;
-        
-    }        
+
+    }
 
     // Send final SYNC
     ir_tx_sendpulse( US_TO_CYCLES(  MIN_DELAY_LT( IR_TX_S_BIT_DELAY_RT_US , IR_CLOCK_SPREAD_PCT ))  ) ;
@@ -532,9 +532,9 @@ void irSendDataPacket(uint8_t bitmask, const uint8_t *packetBuffer, uint8_t len 
 // I put destination (face) first to mirror the stdio.h functions like fprintf().
 
 void irSendData(  uint8_t face , const uint8_t *data , uint8_t len ) {
-       
+
     irSendDataPacket( 1 << face  , data , len );
-    
+
 }
 
 

--- a/libraries/blinklib/src/irdata.cpp
+++ b/libraries/blinklib/src/irdata.cpp
@@ -58,7 +58,7 @@
 
 #define IR_CLOCK_SPREAD_PCT  5      // Max clock spread between TX and RX clocks in percent
 
-#define IR_CHARGE_OVERHEAD 25       // How long does take to fully charge IR after it has triggered?
+#define IR_CHARGE_OVERHEAD 50       // How long does take to fully charge IR after it has triggered?
 
 // Time between consecutive bit flashes
 // Must be long enough that receiver can detect 2 distinct consecutive flashes even at maximum interrupt latency

--- a/libraries/blinklib/src/irdata.h
+++ b/libraries/blinklib/src/irdata.h
@@ -1,6 +1,34 @@
 
- // Called from timer on every click
+// Maximum IR packet size. Larger values more efficient for large block transfers, but use more memory.
+// Packets larger than this are silently discarded.
+// Note that we allocate 6 of these, so memory usage goes up fast with bigger packets sizes.
 
- void updateIRComs(void);
+#define IR_RX_PACKET_SIZE     35
+
+
+ // Called from timer on every click to process newly received IR LED levels
+
+void IrDataPeriodicUpdateComs(void);
+
+// Is there a received data ready to be read on this face?
+
+bool irDataIsPacketReady( uint8_t led );
+
+
+// Returns length of the  data if complete packet is ready (note that zero is valid)
+
+uint8_t irDataPacketLen( uint8_t led );
+
+
+// Get a handle to the received packet buffer.
+// Note only valid after irDataIsPacketReady() turns true and before irDataMarkPacketRead() is called.
+
+const uint8_t *irDataPacketBuffer( uint8_t led );
+
+
+// Mark most recently recieved packet as read, freeing up the buffer to receive the next packet.
+// Note that new packets that start coming in before this is called are sileintly discarded.
+
+void irDataMarkPacketRead( uint8_t led );
 
  

--- a/libraries/blinklib/src/irdata.h
+++ b/libraries/blinklib/src/irdata.h
@@ -1,12 +1,18 @@
+ // Called from timer on every click to process newly received IR LED levels
+ 
+ 
+ // IR Packet functions
+ // Note that there is no error checking on packet data. Packets must be well formed, which means that 
+ // they must start and end with SYNC and have only a multiple of 8 valid bits in between the SYNCs.
+ // If there is any structural error while receiving a potential packet, then it is aborted and we 
+ // start looking for a new one. 
 
 // Maximum IR packet size. Larger values more efficient for large block transfers, but use more memory.
 // Packets larger than this are silently discarded.
 // Note that we allocate 6 of these, so memory usage goes up fast with bigger packets sizes.
 
 #define IR_RX_PACKET_SIZE     35
-
-
- // Called from timer on every click to process newly received IR LED levels
+ 
 
 void IrDataPeriodicUpdateComs(void);
 
@@ -26,7 +32,7 @@ uint8_t irDataPacketLen( uint8_t led );
 const uint8_t *irDataPacketBuffer( uint8_t led );
 
 
-// Mark most recently recieved packet as read, freeing up the buffer to receive the next packet.
+// Mark most recently received packet as read, freeing up the buffer to receive the next packet.
 // Note that new packets that start coming in before this is called are sileintly discarded.
 
 void irDataMarkPacketRead( uint8_t led );

--- a/libraries/blinkstate/src/blinkstate.h
+++ b/libraries/blinkstate/src/blinkstate.h
@@ -25,8 +25,7 @@
 // The value of the data sent and received on faces via IR can be between 0 and IR_DATA_VALUE_MAX
 // If you try to send higher than this, the max value will be sent.
 
-#define IR_DATA_VALUE_MAX UINT8_MAX
-
+#define IR_DATA_VALUE_MAX 63
 
 // The blinksatate library continuously transmits on all IR LEDs
 // when enabled. If you don't want this, then disable it.

--- a/libraries/blinkstate/src/blinkstate.h
+++ b/libraries/blinkstate/src/blinkstate.h
@@ -25,7 +25,7 @@
 // The value of the data sent and received on faces via IR can be between 0 and IR_DATA_VALUE_MAX
 // If you try to send higher than this, the max value will be sent.
 
-#define IR_DATA_VALUE_MAX 100
+#define IR_DATA_VALUE_MAX UINT8_MAX
 
 
 // The blinksatate library continuously transmits on all IR LEDs


### PR DESCRIPTION
No downsides, just tightens up the edges for this communication path. Effectively eliminates data errors for tiles that have LOS. There are still some places for errors to sneak in when tiles are moved, but those will be addressed with error checking. 