### PR TITLE
Replace `map()`, remove debug code

### DIFF
--- a/cores/blinklib/blinklib.h
+++ b/cores/blinklib/blinklib.h
@@ -309,7 +309,7 @@ byte getSerialNumberByte( byte n );
 
 // Map one set to another
 
-long map(word x, word in_min, word in_max, word out_min, word out_max);
+word map(word x, word in_min, word in_max, word out_min, word out_max);
 
 
 


### PR DESCRIPTION
New `map()` function should never overflow, give even distribution over range, and clamp output to min/max range. 

Code should be correct, but completely untested! Please test and LMK if you find any problems. 