### PR TITLE
Add convenience functions for face data.

### DIFF
--- a/cores/blinklib/blinklib.cpp
+++ b/cores/blinklib/blinklib.cpp
@@ -237,6 +237,19 @@ void markDatagramReadOnFace( uint8_t face ) {
     faces[face].inDatagramLen = 0;
 }    
 
+byte* getOutDatagramOnFace( byte face ) {
+    return faces[face].outDatagram;
+}
+
+byte getOutDatagramLengthOnFace( byte face ) {
+    return faces[face].outDatagramLen;
+}
+
+bool isOutDatagramPendingOnFace( byte face ) {
+    return getOutDatagramLengthOnFace(face) != 0;
+}
+
+
 // Jump to the send packet function all way up in the bootloader
 
 uint8_t blinkbios_irdata_send_packet(  uint8_t face, const uint8_t *data , uint8_t len ) {
@@ -854,6 +867,9 @@ void setValueSentOnFace( byte value , byte face ) {
 
 }
 
+byte getValueSentOnFace( byte face ) {
+	return faces[face].outValue;
+}
 
 
 // --------------Button code

--- a/cores/blinklib/blinklib.h
+++ b/cores/blinklib/blinklib.h
@@ -69,6 +69,9 @@ void setValueSentOnFace( byte value , byte face );
 
 void setValueSentOnAllFaces( byte value );
 
+// Returns the current value being sent on the given face.
+byte getValueSentOnFace( byte face );
+
 /* --- Datagram processing */
 
 // A datagram is a set of 1-IR_DATAGRAM_MAX_LEN bytes that are atomically sent over the IR link
@@ -108,6 +111,16 @@ void markDatagramReadOnFace( uint8_t face );
 // Note that if the len>IR_DATAGRAM_LEN then packet will never be sent or recieved
 
 void sendDatagramOnFace(  const void *data, byte len , byte face );
+
+// Returns a pointer to the datagram currently pending to be sent on the given face.
+byte* getOutDatagramOnFace( byte face );
+
+// Returns the side of the datagram currently pending to be sent on the given face. 0 means no
+// datagram is pending.
+byte getOutDatagramLengthOnFace( byte face );
+
+// Returns true if there is a datagram currently pending to be sent on the given face.
+bool isOutDatagramPendingOnFace( byte face );
 
 
 /*


### PR DESCRIPTION
- Allows obtaining the value currently being sent on a face. This
  simplifies and reduces the memory usage of any program that needs to
  modify the value being sent based on the existing one (for instance,
  setting bits. Without this, one needs to keep track of the values
  themselves.
- Allows access to data for datagrams pending to be sent on a given
  face. Juts as above, this simplifies and reduces (here by a lot)
  memory usage of any programs that need access to the outgoing datagram
  (say, to use the data for send retries) and even to the fact that
  there is a pending datagram (no need to keep track of this to prevent
  some code from overwritting the data there unwittingly in a single
  loop iteration.

All in all, this simplifies some usage scenarios for certain programs,
add a nice simimetry with the existing methods and, above all, cam
pottentially save a considerable amount of memory usage form some types
of programs (up to 102 bytes can be saved.

Adding the fact that if these functions are not used they take no extra
storage space, this looks like a no-brainer to me.